### PR TITLE
upgrade to ps 13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-partial": "^2.0.0",
-    "purescript-prelude": "^4.0.0",
+    "purescript-partial": "^2.0.1",
+    "purescript-prelude": "^4.1.0",
     "purescript-functions": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "purescript-psa": "^0.7.0"
   },
   "dependencies": {
-    "viewport-mercator-project": "^5.1.0"
+    "@math.gl/web-mercator": "^3.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^4.8.2",
     "purescript": "^0.12.0",
     "pulp": "^12.2.0",
     "purescript-psa": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint": "^3.17.1",
     "purescript": "^0.12.0",
     "pulp": "^12.2.0",
-    "purescript-psa": "^0.6.0"
+    "purescript-psa": "^0.7.0"
   },
   "dependencies": {
     "viewport-mercator-project": "^5.1.0"

--- a/src/WebMercator/Viewport.js
+++ b/src/WebMercator/Viewport.js
@@ -1,5 +1,5 @@
 "use strict";
-var vmp = require("viewport-mercator-project");
+var vmp = require("@math.gl/web-mercator");
 
 exports.unpack = function(vp) {
   return {


### PR DESCRIPTION
- upgrade to ps-13
- the mercator-viewport dependency is now archived, active development takes place here https://github.com/uber-web/math.gl . I switched our dependency to point to this repo